### PR TITLE
Move Inlineobjc imports to implementation file.

### DIFF
--- a/LzmaSDK-ObjC.podspec
+++ b/LzmaSDK-ObjC.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "LzmaSDK-ObjC"
-  s.version          = "1.0.1"
+  s.version          = "1.0.2"
   s.summary          = "Lzma SDK for Objective-C based on extended functionality of the C++ LZMA code"
 
 # This description is used to generate tags and improve search results.

--- a/LzmaSDKObjC.podspec
+++ b/LzmaSDKObjC.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "LzmaSDKObjC"
-  s.version          = "1.0.1"
+  s.version          = "1.0.2"
   s.summary          = "Lzma SDK for Objective-C based on extended functionality of the C++ LZMA code"
 
 # This description is used to generate tags and improve search results.

--- a/Pod/Classes/src/LzmaSDKObjCItem.h
+++ b/Pod/Classes/src/LzmaSDKObjCItem.h
@@ -22,8 +22,6 @@
 
 
 #import <Foundation/Foundation.h>
-#import <Inlineobjc/NSString+Inlineobjc.h>
-#import <Inlineobjc/NSArray+Inlineobjc.h>
 
 /**
  @brief Archive item class for the file or directory.

--- a/Pod/Classes/src/LzmaSDKObjCItem.mm
+++ b/Pod/Classes/src/LzmaSDKObjCItem.mm
@@ -23,6 +23,8 @@
 
 #import "LzmaSDKObjCItem.h"
 #import "LzmaSDKObjCItem+Private.h"
+#import <Inlineobjc/NSString+Inlineobjc.h>
+#import <Inlineobjc/NSArray+Inlineobjc.h>
 
 @implementation LzmaSDKObjCItem
 


### PR DESCRIPTION
I get errors when using the Cocoapod in a command line tool. I'm not sure exactly why, but it's these two imports. They're not really part of the public interface anyway, so this seems like the right place for them.