### PR TITLE
Adds Throw to IsAbsolutePath and GetRootPrefixSize

### DIFF
--- a/Pod/Classes/lzma/CPP/Windows/FileName.cpp
+++ b/Pod/Classes/lzma/CPP/Windows/FileName.cpp
@@ -334,12 +334,12 @@ unsigned GetRootPrefixSize(const wchar_t *s) throw()
 
 #else // _WIN32
 
-bool IsAbsolutePath(const wchar_t *s) { return IS_SEPAR(s[0]); }
+bool IsAbsolutePath(const wchar_t *s) throw() { return IS_SEPAR(s[0]); }
 
 #ifndef USE_UNICODE_FSTRING
 unsigned GetRootPrefixSize(CFSTR s) { return IS_SEPAR(s[0]) ? 1 : 0; }
 #endif
-unsigned GetRootPrefixSize(const wchar_t *s) { return IS_SEPAR(s[0]) ? 1 : 0; }
+unsigned GetRootPrefixSize(const wchar_t *s) throw() { return IS_SEPAR(s[0]) ? 1 : 0; }
 
 #endif // _WIN32
 

--- a/Pod/Classes/src/LzmaSDKObjCReader.h
+++ b/Pod/Classes/src/LzmaSDKObjCReader.h
@@ -96,7 +96,7 @@ LZMASDKOBJC_EXTERN NSString * const _Nonnull kLzmaSDKObjCErrorDomain;
 /**
  @brief Archive reader delegate.
  */
-@property (nonatomic, weak) id<LzmaSDKObjCReaderDelegate> delegate;
+@property (nonatomic, weak) id<LzmaSDKObjCReaderDelegate> _Nullable delegate;
 
 
 /**


### PR DESCRIPTION
I added this because it wasn't building on iOS 9.3 in Xcode 7.3 beta without it.  Testing it in iOS 8 with Xcode 7.2 works fine from what I can tell.  