### PR TITLE
Fix Undefined value access

### DIFF
--- a/src/LzmaSDKObjCExtractCallback.mm
+++ b/src/LzmaSDKObjCExtractCallback.mm
@@ -139,7 +139,7 @@ namespace LzmaSDKObjC
 
 		fullPath = [fullPath stringByAppendingPathComponent:fileName];
 
-		PROPVARIANT isDirProp;
+		PROPVARIANT isDirProp = {0};
 		HRESULT res = _archive->GetProperty(index, kpidIsDir, &isDirProp);
 		if (res != S_OK)
 		{


### PR DESCRIPTION
VariantClear(VARIANTARG *prop) called with undefined value, pointer being freed was not allocated.

1.GetProperty with Undefined value
2.PropVariant_Clear() called in GetProperty
3.VariantClear() called in PropVariant_Clear
4.if (prop->vt == VT_BSTR) , then call free() with undefined pointer.