### PR TITLE
Fix conflicting nullability specifier warnning

### DIFF
--- a/src/LzmaSDKObjCReader.h
+++ b/src/LzmaSDKObjCReader.h
@@ -159,8 +159,8 @@ LZMASDKOBJC_EXTERN NSString * const _Nonnull kLzmaSDKObjCErrorDescrEncDecNotCrea
 - (BOOL) test:(nullable NSArray<LzmaSDKObjCItem *> *) items;
 
 #pragma mark - Unavailable
-- (nullable instancetype) init NS_UNAVAILABLE;
-+ (nullable instancetype) new NS_UNAVAILABLE;
+- (_Null_unspecified instancetype) init NS_UNAVAILABLE;
++ (_Null_unspecified instancetype) new NS_UNAVAILABLE;
 
 @end
 

--- a/src/LzmaSDKObjCReader.mm
+++ b/src/LzmaSDKObjCReader.mm
@@ -229,7 +229,7 @@ static void * _LzmaSDKObjCReaderGetVoidCallback1(void * context) {
 }
 
 #if defined(DEBUG) || defined(_DEBUG)
-- (nullable instancetype) init {
+- (instancetype) init {
 	LZMASDK_DEBUG_ERR("Reader can't be initialized with `init`, use 'initWithFileURL' instead");
 	NSAssert(0, @"Use 'initWithFileURL' instead");
 	return nil;

--- a/src/LzmaSDKObjCWriter.h
+++ b/src/LzmaSDKObjCWriter.h
@@ -209,7 +209,7 @@
 - (BOOL) write;
 
 #pragma mark - Unavailable
-- (nullable instancetype) init NS_UNAVAILABLE;
-+ (nullable instancetype) new NS_UNAVAILABLE;
+- (_Null_unspecified instancetype) init NS_UNAVAILABLE;
++ (_Null_unspecified instancetype) new NS_UNAVAILABLE;
 
 @end

--- a/src/LzmaSDKObjCWriter.mm
+++ b/src/LzmaSDKObjCWriter.mm
@@ -72,7 +72,7 @@ static void _LzmaSDKObjCWriterSetFloatCallback(void * context, float value) {
 }
 
 #if defined(DEBUG) || defined(_DEBUG)
-- (nullable instancetype) init {
+- (instancetype) init {
 	LZMASDK_DEBUG_ERR("Writer can't be initialized with `init`, use 'initWithFileURL' instead");
 	NSAssert(0, @"Use 'initWithFileURL' instead");
 	return nil;


### PR DESCRIPTION
Fixes XCode warnings:  
⚠️ Conflicting nullability specifier on return types, 'nullable' conflicts with existing specifier 'nonnull'

`NSObject.h` - no nullability specifier:
```objc
- (instancetype)init;
+ (instancetype)new OBJC_SWIFT_UNAVAILABLE("use object initializers instead");
```